### PR TITLE
Despliegue automático de contenedores con la infraestructura auxiliar 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,6 @@ test.script
 !hsqldb/lib/*zip
 !kafka_2.11-1.0.1/libs/*.jar
 tmp_kafka/
+
+# GFM View
+.README.md.html

--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ tmp_kafka/
 
 # GFM View
 .README.md.html
+
+# src/main/bin exception:
+!src/main/bin

--- a/README.md
+++ b/README.md
@@ -54,8 +54,10 @@ docker-compose -f docker-compose.yml -f docker-compose.management.yml up
   
  |  CONTENEDOR   | DIRECCIÓN                                   | FICHERO                                                        |
  |---------------|---------------------------------------------|----------------------------------------------------------------|
+ | postgres      | [postgres:5432](http://localhost:5432)      | [docker-compose.yml](docker-compose.yml)                       |
  | zookeeper     | [zookeeper:2181](http://localhost:2181)     | [docker-compose.yml](docker-compose.yml)                       |
  | kafka         | [kafka:9092](http://localhost:9092)         | [docker-compose.yml](docker-compose.yml)                       |
+ | pgadmin4      | [pgadmin4:5433](http://localhost:5433)      | [docker-compose.managament.yml](docker-compose.managament.yml) |
  | kafka-manager | [kafka-manager:9000](http://localhost:9000) | [docker-compose.managament.yml](docker-compose.managament.yml) |
  
 **IMPORTANTE:** En el caso de utilizar *Docker Compose* con *Docker Toolbox/Machine*

--- a/README.md
+++ b/README.md
@@ -71,3 +71,28 @@ suficiente con la combinación de teclas Ctrl+C o en su defecto, ejecutando la o
 docker-compose down
 ~~~
 
+Para eliminar en MS-Windows todos los objetos creados en Docker y reiniciar el 
+despliegue desde cero puede ejecutarse la siguiente secuencia de ordenes 
+(disponibles en el fichero por lotes: 
+'[bin/docker-remove-objects.bat](bin/docker-remove-objects.bat)') :
+
+~~~batchfile
+@echo off
+REM Stop all containers: 
+docker ps
+FOR /f "tokens=*" %%i IN ('docker ps -aq') DO docker container stop %%i 
+REM Remove all container:
+docker container ls
+FOR /f "tokens=*" %%i IN ('docker ps -aq') DO docker container rm %%i 
+REM Remove all volumes:
+docker volume ls
+FOR /f "tokens=*" %%i IN ('docker volume ls -q') DO docker volume rm %%i 
+REM Remove all networks:
+docker network ls
+FOR /f "tokens=*" %%i IN ('docker network ls -q') DO docker network rm %%i 
+REM Remove all images:
+docker image ls
+FOR /f "tokens=*" %%i IN ('docker images --format "{{.ID}}"') DO docker rmi %%i
+pause
+~~~
+

--- a/README.md
+++ b/README.md
@@ -26,3 +26,48 @@ Este fichero batch lleva a cabo las siguientes acciones:
 2. Ejecuta una instancia la base de datos HSQLDB
 3. Inicia Apache Zookeeper y Apache Kafka 
 4. Finalmente ejecuta los módulos de Agentes, InciManager e InciDashboard, para así poder testear la funcionalidad completa.
+
+### Despliegue automático mediante contenedores Docker
+
+Si se dispone de una instancia de [Docker](https://www.docker.com) ya instalada,
+ es posible desplegar automáticamente todos los servicios necesarios utilizando 
+ la herramienta de orquestación de contenedores 
+ [Docker-Compose](https://docs.docker.com/compose/overview). Para ello, basta 
+ con situarse en el directorio raiz del proyecto (donde se encuentra el fichero
+  [docker-compose.yml](docker-compose.yml)) y ejecutar en la consola:
+
+~~~batchfile
+docker-compose up
+~~~
+
+De forma opcional, es posible combinar al despliegue anterior diversos contenedores 
+auxiliares destinados a gestionar y supervisar el funcionamiento de dichos servicios: 
+
+~~~batchfile
+docker-compose -f docker-compose.yml -f docker-compose.management.yml up
+~~~
+ 
+ Una vez desplegado, cada contenedor es accesible a través del puerto 
+ correspondiente del servidor Docker donde se ejecutan dichos contenedores (en 
+ el caso de tratarse de la misma máquina, puede sustituirse por la combinación:
+ *localhost:puerto*):
+  
+ |  CONTENEDOR   | DIRECCIÓN                                   | FICHERO                                                        |
+ |---------------|---------------------------------------------|----------------------------------------------------------------|
+ | zookeeper     | [zookeeper:2181](http://localhost:2181)     | [docker-compose.yml](docker-compose.yml)                       |
+ | kafka         | [kafka:9092](http://localhost:9092)         | [docker-compose.yml](docker-compose.yml)                       |
+ | kafka-manager | [kafka-manager:9000](http://localhost:9000) | [docker-compose.managament.yml](docker-compose.managament.yml) |
+ 
+**IMPORTANTE:** En el caso de utilizar *Docker Compose* con *Docker Toolbox/Machine*
+ en *MS-Windows*,  es necesario establecer primero la variable de entorno 
+ [COMPOSE_CONVERT_WINDOWS_PATHS=1](https://docs.docker.com/compose/reference/envvars/#compose_convert_windows_paths)
+  antes de poder ejecutar con exito `docker-compose` 
+  (*[breaking changes 1.9.0 (2016-11-16)](https://github.com/docker/compose/blob/master/CHANGELOG.md#190-2016-11-16))*. 
+
+Para detener la ejecución de todos los servicios de forma interactiva es 
+suficiente con la combinación de teclas Ctrl+C o en su defecto, ejecutando la orden:
+
+~~~batchfile
+docker-compose down
+~~~
+

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ docker-compose -f docker-compose.yml -f docker-compose.management.yml up
  | postgres      | [postgres:5432](http://localhost:5432)      | [docker-compose.yml](docker-compose.yml)                       |
  | zookeeper     | [zookeeper:2181](http://localhost:2181)     | [docker-compose.yml](docker-compose.yml)                       |
  | kafka         | [kafka:9092](http://localhost:9092)         | [docker-compose.yml](docker-compose.yml)                       |
- | pgadmin4      | [pgadmin4:5433](http://localhost:5433)      | [docker-compose.managament.yml](docker-compose.managament.yml) |
- | kafka-manager | [kafka-manager:9000](http://localhost:9000) | [docker-compose.managament.yml](docker-compose.managament.yml) |
+ | pgadmin4      | [pgadmin4:5433](http://localhost:5433)      | [docker-compose.management.yml](docker-compose.management.yml) |
+ | kafka-manager | [kafka-manager:9000](http://localhost:9000) | [docker-compose.management.yml](docker-compose.management.yml) |
  
 **IMPORTANTE:** En el caso de utilizar *Docker Compose* con *Docker Toolbox/Machine*
  en *MS-Windows*,  es necesario establecer primero la variable de entorno 

--- a/docker-compose.management.yml
+++ b/docker-compose.management.yml
@@ -2,6 +2,17 @@ version: '3.6'
 
 services:
 
+  pgadmin4:
+    image: dpage/pgadmin4
+    ports:
+      - "80:5433"
+    environment:
+      PGADMIN_DEFAULT_EMAIL: container@pgadmin.org
+      PGADMIN_DEFAULT_PASSWORD: Conta1ner
+      PGADMIN_SERVER_NAME: pgadmin4
+    links:
+      - postgres
+
   kafka-manager:
     image: sheepkiller/kafka-manager:latest
     ports:

--- a/docker-compose.management.yml
+++ b/docker-compose.management.yml
@@ -1,0 +1,16 @@
+version: '3.6'
+
+services:
+
+  kafka-manager:
+    image: sheepkiller/kafka-manager:latest
+    ports:
+      - "9000:9000"
+    environment:
+      ZK_HOSTS: zookeeper:2181
+      APPLICATION_SECRET: changeit
+      KM_ARGS: -Djava.net.preferIPv4Stack=true
+    links:
+      - zookeeper
+      - kafka
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '3.6'
+
+services:
+
+  zookeeper:
+    image: wurstmeister/zookeeper
+    ports:
+      - "2181:2181"
+
+  kafka:
+    image: wurstmeister/kafka
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_LISTENERS: PLAINTEXT://:9092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181  
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    links:
+      - zookeeper

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,15 @@ version: '3.6'
 
 services:
 
+  postgres:
+    image: postgres:alpine
+    ports:
+      - "5432:5432"
+    restart: always
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: changeme
+
   zookeeper:
     image: wurstmeister/zookeeper
     ports:
@@ -19,3 +28,4 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     links:
       - zookeeper
+

--- a/src/main/bin/docker-remove-objects.bat
+++ b/src/main/bin/docker-remove-objects.bat
@@ -1,0 +1,17 @@
+@echo off
+REM Stop all containers: 
+docker ps
+FOR /f "tokens=*" %%i IN ('docker ps -aq') DO docker container stop %%i 
+REM Remove all container:
+docker container ls
+FOR /f "tokens=*" %%i IN ('docker ps -aq') DO docker container rm %%i 
+REM Remove all volumes:
+docker volume ls
+FOR /f "tokens=*" %%i IN ('docker volume ls -q') DO docker volume rm %%i 
+REM Remove all networks:
+docker network ls
+FOR /f "tokens=*" %%i IN ('docker network ls -q') DO docker network rm %%i 
+REM Remove all images:
+docker image ls
+FOR /f "tokens=*" %%i IN ('docker images --format "{{.ID}}"') DO docker rmi %%i
+pause


### PR DESCRIPTION
Incluye lo necesario para poder desplegar automáticamente los contenedores Docker con la infraestructura auxiliar (base de datos, Kafka, etc):

|  CONTENEDOR   | DIRECCIÓN                                   | FICHERO                                                        |
 |---------------|---------------------------------------------|----------------------------------------------------------------|
 | postgres      | [postgres:5432](http://localhost:5432)      | [docker-compose.yml](docker-compose.yml)                       |
 | zookeeper     | [zookeeper:2181](http://localhost:2181)     | [docker-compose.yml](docker-compose.yml)                       |
 | kafka         | [kafka:9092](http://localhost:9092)         | [docker-compose.yml](docker-compose.yml)                       |
 | pgadmin4      | [pgadmin4:5433](http://localhost:5433)      | [docker-compose.management.yml](docker-compose.management.yml) |
 | kafka-manager | [kafka-manager:9000](http://localhost:9000) | [docker-compose.management.yml](docker-compose.management.yml) |

Ver también: Issue #1 Issue #5  